### PR TITLE
Create portable toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TOP=$(PWD)
 TOOLCHAIN=$(TOP)/xtensa-lx106-elf
+OPENSOURCE=n
 
 all: sdk_patch $(TOOLCHAIN)/lib/libhal.a $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
 	@echo
@@ -7,8 +8,17 @@ all: sdk_patch $(TOOLCHAIN)/lib/libhal.a $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
 	@echo
 	@echo 'export PATH=$(TOOLCHAIN)/bin:$$PATH'
 	@echo
+ifeq ($(OPENSOURCE),y)
+	@echo "Espressif ESP8266 SDK is installed. Toolchain contains only Open Source components"
+	@echo "To link external proprietary libraries add:"
+	@echo
+	@echo "xtensa-lx106-elf-gcc -I$(TOP)/sdk/include -L$(TOP)/sdk/lib"
+	@echo
+else
 	@echo "Espressif ESP8266 SDK is installed, additional blobs are installed into the toolchain"
 	@echo
+endif
+
 
 sdk_patch: sdk/lib/libpp.a
 
@@ -46,10 +56,12 @@ toolchain: esp_iot_sdk_v0.9.2/.dir
 	sed -r -i s%CT_INSTALL_DIR_RO=y%"#"CT_INSTALL_DIR_RO=y% .config
 	echo CT_STATIC_TOOLCHAIN=y >> .config
 	./ct-ng build
+ifneq ($(OPENSOURCE),y)
 	@echo "Installing additional SDK headers"
 	@cp -Rfv sdk/include/* $(TOOLCHAIN)/xtensa-lx106-elf/usr/include/
 	@echo "Installing additional SDK blobs"
 	@cp -Rfv sdk/lib/* $(TOOLCHAIN)/xtensa-lx106-elf/lib/
+endif
 
 crosstool-NG/ct-ng: crosstool-NG/bootstrap
 	make -C crosstool-NG -f ../Makefile ct-ng


### PR DESCRIPTION
This commit adds changes required for the toolchain to be
portable:
- Toolchain built is now static
- All SDK headers are installed into the toolchain itself
- All blobs from SDK are installed into toolchain itself
- Toolchain directory name is its GNU_TARGET_NAME by default

This also removes the need to specify the -L and -I flags
while building the actual software to include SDK libraries

Signed-off-by: Andrew Andrianov andrew@ncrmnt.org
