### PR TITLE
Add submodule for esptool-ck and adjust Makefile for it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "esptool"]
 	path = esptool
 	url = https://github.com/themadinventor/esptool
+[submodule "esptool-ck"]
+	path = esptool-ck
+	url = https://github.com/igrr/esptool-ck.git

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ STANDALONE = y
 
 .PHONY: crosstool-NG toolchain libhal libcirom sdk
 
-all: esptool libcirom standalone sdk sdk_patch $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/libhal.a $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
+all: esptool esptool-ck libcirom standalone sdk sdk_patch $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/libhal.a $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
 	@echo
 	@echo "Xtensa toolchain is built, to use it:"
 	@echo
@@ -38,6 +38,10 @@ endif
 
 esptool: toolchain
 	cp esptool/esptool.py $(TOOLCHAIN)/bin/
+
+esptool-ck: toolchain
+	make -C esptool-ck -f Makefile
+	cp esptool-ck/esptool $(TOOLCHAIN)/bin/
 
 $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/lib/libcirom.a: $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/lib/libc.a $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
 	@echo "Creating irom version of libc..."


### PR DESCRIPTION
This adds the esptool-ck as submodule and in Makefile (only "esptool", written in C).
It might need discussion, as I know this is somewhat a competitive software to the esptool.py, but it is
1. still used by many projects to build the firmware bin files from elf, while esptool.py is used for flashing
2. it was more recently updated and seems to consider support for flashing more boards in the future (see "Support for NodeMCU board is coming up.")

I am new to the esp8266, so I might be wrong with this. The community seems to be still quite unsure about these tools?