### PR TITLE
Add support for SDK 1.0.0 including c99 patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 TOP = $(PWD)
 TOOLCHAIN = $(TOP)/xtensa-lx106-elf
-VENDOR_SDK = 0.9.5
+VENDOR_SDK = 1.0.0
 
 UNZIP = unzip -q -o
 
 VENDOR_SDK_ZIP = $(VENDOR_SDK_ZIP_$(VENDOR_SDK))
 VENDOR_SDK_DIR = $(VENDOR_SDK_DIR_$(VENDOR_SDK))
 
+VENDOR_SDK_ZIP_1.0.0 = esp_iot_sdk_v1.0.0_15_03_20.zip
+VENDOR_SDK_DIR_1.0.0 = esp_iot_sdk_v1.0.0
 VENDOR_SDK_ZIP_0.9.6b1 = esp_iot_sdk_v0.9.6_b1_15_02_15.zip
 VENDOR_SDK_DIR_0.9.6b1 = esp_iot_sdk_v0.9.6_b1
 VENDOR_SDK_ZIP_0.9.5 = esp_iot_sdk_v0.9.5_15_01_23.zip
@@ -49,6 +51,10 @@ $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/lib/libcirom.a: $(TOOLCHAIN)/xtensa-lx106-
 libcirom: $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/lib/libcirom.a
 
 sdk_patch: .sdk_patch_$(VENDOR_SDK)
+
+.sdk_patch_1.0.0:
+	patch -d $(VENDOR_SDK_DIR_1.0.0) -p1 < c_types-c99.patch
+	@touch $@
 
 .sdk_patch_0.9.6b1:
 	patch -d $(VENDOR_SDK_DIR_0.9.6b1) -p1 < c_types-c99.patch
@@ -99,6 +105,9 @@ $(VENDOR_SDK_DIR)/.dir: $(VENDOR_SDK_ZIP)
 	$(UNZIP) $^
 	-mv License $(VENDOR_SDK_DIR)
 	touch $@
+
+esp_iot_sdk_v1.0.0_15_03_20.zip:
+	wget --content-disposition "http://bbs.espressif.com/download/file.php?id=250"
 
 esp_iot_sdk_v0.9.6_b1_15_02_15.zip:
 	wget --content-disposition "http://bbs.espressif.com/download/file.php?id=220"


### PR DESCRIPTION
Hi

one thing I noticed when tasting this against `esp8266-frankenstein` is that for systems that replace the binary `lwip` library with their own version need to add an additional function, `espconn_init()` that wasn't previously required.