### PR TITLE
Yosemite/6.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "crosstool-NG"]
 	path = crosstool-NG
-	url = https://github.com/jcmvbkbc/crosstool-NG
+	url = https://github.com/dirkx/crosstool-NG.git
 	branch = lx106-g++
 [submodule "lx106-hal"]
 	path = lx106-hal

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ _toolchain:
 
 crosstool-NG: .ng_patch crosstool-NG/ct-ng
 
-crosstool-NG/ct-ng: crosstool-NG/bootstrap
+crosstool-NG/ct-ng: crosstool-NG/bootstrap .ng_patch
 	make -C crosstool-NG -f ../Makefile _ct-ng
 
 .ng_patch: crosstool-NG.patch

--- a/Makefile
+++ b/Makefile
@@ -179,11 +179,14 @@ _toolchain:
 	cat ../crosstool-config-overrides >> .config
 	./ct-ng build
 
-
-crosstool-NG: crosstool-NG/ct-ng
+crosstool-NG: .ng_patch crosstool-NG/ct-ng
 
 crosstool-NG/ct-ng: crosstool-NG/bootstrap
 	make -C crosstool-NG -f ../Makefile _ct-ng
+
+.ng_patch: crosstool-NG.patch
+	patch -d crosstool-NG -p 1 < crosstool-NG.patch
+	@touch $@
 
 _ct-ng:
 	./bootstrap

--- a/README.md
+++ b/README.md
@@ -43,19 +43,20 @@ $ sudo apt-get install make unrar autoconf automake libtool gcc g++ gperf \
     flex bison texinfo gawk ncurses-dev libexpat-dev python sed
 ```
 
-## MacOS:
+## MacOS with Brew:
 ```bash
 $ brew tap homebrew/dupes
 $ brew install binutils coreutils automake wget gawk libtool gperf gnu-sed --with-default-names grep
 $ export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 
-In addition to the development tools MacOS needs a case-sensitive filesystem.
-You might need to create a virtual disk and build esp-open-sdk on it:
+## MacOS with Mac Ports:
 ```bash
-$ sudo hdiutil create ~/Documents/case-sensitive.dmg -volname "case-sensitive" -size 10g -fs "Case-sensitive HFS+"
-$ sudo hdiutil mount ~/Documents/case-sensitive.dmg
-$ cd /Volumes/case-sensitive
+$ sudo port install gsed gawk
+$ sudo mkdir /opt/local/gnubin
+$ sudo ln /opt/local/bin/gsed /opt/local/gnubin/sed
+$ sudo ln /opt/local/bin/gawk /opt/local/gnubin/awk
+$ export PATH="/opt/local/gnubin:$PATH"
 ```
 
 For other Debian/Ubuntu versions, dependencies may be somewhat different.

--- a/crosstool-NG.patch
+++ b/crosstool-NG.patch
@@ -1,0 +1,23 @@
+diff --git crosstool-NG/scripts/crosstool-NG.sh.in crosstool-NG/scripts/crosstool-NG.sh.in
+--- a/scripts/crosstool-NG.sh.in
++++ b/scripts/crosstool-NG.sh.in
+@@ -84,14 +84,14 @@
+ 
+ # Where will we work?
+-CT_WORK_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}"
+-CT_DoExecLog ALL mkdir -p "${CT_WORK_DIR}"
+-CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/backtrace"
++# CT_WORK_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}"
++# CT_DoExecLog ALL mkdir -p "${CT_WORK_DIR}"
++# CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/backtrace"
+ 
+ # Check build file system case-sensitiveness
+-CT_DoExecLog DEBUG touch "${CT_WORK_DIR}/foo"
+-CT_TestAndAbort "Your file system in '${CT_WORK_DIR}' is *not* case-sensitive!" -f "${CT_WORK_DIR}/FOO"
+-CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/foo"
++# CT_DoExecLog DEBUG touch "${CT_WORK_DIR}/foo"
++# CT_TestAndAbort "Your file system in '${CT_WORK_DIR}' is *not* case-sensitive!" -f "${CT_WORK_DIR}/FOO"
++# CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/foo"
+ 
+ # Check the user is using an existing SHELL to be used by ./configure and Makefiles
+ CT_TestOrAbort "The CONFIG_SHELL '${CT_CONFIG_SHELL}' is not valid" -f "${CT_CONFIG_SHELL}" -a -x "${CT_CONFIG_SHELL}"

--- a/crosstool-NG.patch
+++ b/crosstool-NG.patch
@@ -1,7 +1,9 @@
-diff --git crosstool-NG/scripts/crosstool-NG.sh.in crosstool-NG/scripts/crosstool-NG.sh.in
+diff --git a/scripts/crosstool-NG.sh.in b/scripts/crosstool-NG.sh.in
+index cd65d5b..a6a04ef 100644
 --- a/scripts/crosstool-NG.sh.in
 +++ b/scripts/crosstool-NG.sh.in
-@@ -84,14 +84,14 @@
+@@ -84,14 +84,14 @@ for d in            \
+ done
  
  # Where will we work?
 -CT_WORK_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}"
@@ -21,3 +23,17 @@ diff --git crosstool-NG/scripts/crosstool-NG.sh.in crosstool-NG/scripts/crosstoo
  
  # Check the user is using an existing SHELL to be used by ./configure and Makefiles
  CT_TestOrAbort "The CONFIG_SHELL '${CT_CONFIG_SHELL}' is not valid" -f "${CT_CONFIG_SHELL}" -a -x "${CT_CONFIG_SHELL}"
+@@ -271,9 +271,9 @@ CT_DoExecLog ALL mkdir -p "${CT_HOST_COMPLIBS_DIR}"
+ [ -n "${CT_DEBUG_CT_SAVE_STEPS}" ] && CT_DoExecLog ALL mkdir -p "${CT_STATE_DIR}"
+ 
+ # Check install file system case-sensitiveness
+-CT_DoExecLog DEBUG touch "${CT_PREFIX_DIR}/foo"
+-CT_TestAndAbort "Your file system in '${CT_PREFIX_DIR}' is *not* case-sensitive!" -f "${CT_PREFIX_DIR}/FOO"
+-CT_DoExecLog DEBUG rm -f "${CT_PREFIX_DIR}/foo"
++# CT_DoExecLog DEBUG touch "${CT_PREFIX_DIR}/foo"
++# CT_TestAndAbort "Your file system in '${CT_PREFIX_DIR}' is *not* case-sensitive!" -f "${CT_PREFIX_DIR}/FOO"
++# CT_DoExecLog DEBUG rm -f "${CT_PREFIX_DIR}/foo"
+ 
+ # Kludge: CT_INSTALL_DIR and CT_PREFIX_DIR might have grown read-only if
+ # the previous build was successful.
+


### PR DESCRIPTION
Few minor tweaks to allow the toolchain to work on OSX; long term will require the change: https://github.com/jcmvbkbc/crosstool-NG/pull/10 to the crosstool to me pulled in.

Also disables the case-sensitivity check (seems to be no longer required for this cross platform build) and updates the docs.