### PR TITLE
add instructions for ubuntu 15.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ To build the standalone SDK and toolchain, you need a GNU/POSIX system
 (Linux, BSD, MacOSX, Windows with Cygwin) with the standard GNU development
 tools installed: gcc, binutils, flex, bison, etc.
 
+## Ubuntu 15.04
+```
+$ sudo apt-get install make unrar autoconf automake libtool-bin gcc g++ gperf \
+    flex bison texinfo gawk ncurses-dev libexpat-dev python sed
+```
+
 ## Ubuntu 14.04
 ```
 $ sudo apt-get install make unrar autoconf automake libtool gcc g++ gperf \


### PR DESCRIPTION
Ubuntu 15.04 and later requires libtool-bin instead of libtool