### PR TITLE
Allow empty_user_rf_pre_init to be overridden

### DIFF
--- a/empty_user_rf_pre_init.c
+++ b/empty_user_rf_pre_init.c
@@ -1,5 +1,6 @@
 // Provide default empty implementation of user_rf_pre_init
 // to maintain compatibility with older SDK versions.
+__attribute__((weak))
 void user_rf_pre_init(void)
 {
 }


### PR DESCRIPTION
Currently, the empty `user_rf_pre_init` causes a link error if the user has already defined it. Making it weak would solve this issue.