### PR TITLE
Compile newlib with -DMALLOC_PROVIDED

### DIFF
--- a/9000-malloc-provided.patch
+++ b/9000-malloc-provided.patch
@@ -1,0 +1,10 @@
+--- a/newlib/configure.host	2015-08-14 16:31:23.033541019 +0000
++++ b/newlib/configure.host	2015-08-14 16:31:28.757594282 +0000
+@@ -286,6 +286,7 @@
+ 	libm_machine_dir=xtensa
+ 	machine_dir=xtensa
+ 	newlib_cflags="${newlib_cflags} -mlongcalls"
++	newlib_cflags="${newlib_cflags} -DMALLOC_PROVIDED"
+ 	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED"
+         ;;
+   z8k)

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,7 @@ _toolchain:
 crosstool-NG: crosstool-NG/ct-ng
 
 crosstool-NG/ct-ng: crosstool-NG/bootstrap
+	cp 9000-malloc-provided.patch crosstool-NG/local-patches/newlib/2.0.0
 	make -C crosstool-NG -f ../Makefile _ct-ng
 
 _ct-ng:


### PR DESCRIPTION
ESP provides its own malloc, so whenever newlib tries to use its own implementation, bad things happen.
This way, malloc symbols remain external in libc.a and can be redirected to the ESP versions.
Right now this is left to the user, though an argument can be made for including them.

This change should not break any existing users because newlib's functions that use memory allocation would not work correctly anyway. This change makes use of those functions possible with appropriate malloc function definitions (trivial shims to the pvPort* variants).