### PR TITLE
Update link to crosstool-NG

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "crosstool-NG"]
 	path = crosstool-NG
 	url = https://github.com/jcmvbkbc/crosstool-NG
-	branch = lx106-g++
+	branch = xtensa-1.22.x
 [submodule "lx106-hal"]
 	path = lx106-hal
 	url = https://github.com/tommie/lx106-hal


### PR DESCRIPTION
There has been a lot of work on crostool-NG since the link to the repository was added,
and some important issues fixed. For example, a mirror was added for
www.multiprecision.org. 

I tested it with a hello world project and it works ok. So unless there is a reason to stay on the old version (like failing the build on some other project), lets upgrade.