### PR TITLE
Enable the SDK version to be configured from the make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TOOLCHAIN = $(TOP)/xtensa-lx106-elf
 
 # Vendor SDK version to install, see VENDOR_SDK_ZIP_* vars below
 # for supported versions.
-VENDOR_SDK = 1.4.0
+VENDOR_SDK ?= 1.4.0
 
 .PHONY: crosstool-NG toolchain libhal libcirom sdk
 


### PR DESCRIPTION
A really minor change to let the VENDOR_SDK variable be set via the command line so you can easily switch between versions without modifying the Makefile