### PR TITLE
Install lwIP headers into toolchain sysroot for easy access.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,9 @@ lwip: toolchain sdk_patch
 	make -C esp-open-lwip -f Makefile.open install \
 	    CC=$(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc \
 	    PREFIX=$(TOOLCHAIN)
+	cp -a esp-open-lwip/include/arch esp-open-lwip/include/lwip esp-open-lwip/include/netif \
+	    esp-open-lwip/include/lwipopts.h \
+	    $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/include/
 
 ESP8266_NONOS_SDK_V1.5.2_16_01_29.zip:
 	wget --content-disposition "http://bbs.espressif.com/download/file.php?id=1079"


### PR DESCRIPTION
"arch" directory (and somewhat "netif" too) aren't namespaced well enough,
but they're still kind of system headers, as lwIP is a foundation of ESP
networking, so any conflicts would be problem of conflicting packages.