### PR TITLE
Fix lwip library build when building STANDALONE=y

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ lwip: toolchain sdk_patch
 ifeq ($(STANDALONE),y)
 	make -C esp-open-lwip -f Makefile.open install \
 	    CC=$(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc \
+	    AR=$(TOOLCHAIN)/bin/xtensa-lx106-elf-ar \	    
 	    PREFIX=$(TOOLCHAIN)
 	cp -a esp-open-lwip/include/arch esp-open-lwip/include/lwip esp-open-lwip/include/netif \
 	    esp-open-lwip/include/lwipopts.h \


### PR DESCRIPTION
When building STANDALONE=y toolchain fails to build do to lwip library failing to build. Lwip library file "liblwip_open.a" fails to build because its looking for xtensa-lx106-elf-ar in wrong path. Proposed fix is to pass the correct AR path to esp-open-lwip/Makefile.open as it was done with CC path.