### PR TITLE
Docker anyone?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y update && apt-get install -yq software-properties-common python-software-properties
+RUN add-apt-repository -y multiverse
+RUN apt-get update && apt-get install -yq \
+    make \
+    unrar \
+    bzip2 \
+    autoconf \
+    automake \
+    libtool \
+    gcc \
+    g++ \
+    gperf \
+    flex \
+    bison \
+    texinfo \
+    gawk \
+    ncurses-dev \
+    libexpat-dev \
+    python \
+    python-serial \
+    sed \
+    git \
+    unzip \
+    bash \
+    help2man \
+    libtool-bin \
+    wget
+
+RUN useradd esp-open-sdk -m -G sudo
+RUN echo 'esp-open-sdk:secrete' | chpasswd
+
+# Assuming this dockerfile is in cwd with repo cloned
+COPY . /home/esp-open-sdk
+RUN chown esp-open-sdk:esp-open-sdk /home/esp-open-sdk -R
+USER esp-open-sdk
+
+ENV PATH /home/esp-open-sdk/xtensa-lx106-elf/bin/:$PATH
+WORKDIR /home/esp-open-sdk
+RUN alias xgcc="xtensa-lx106-elf-gcc"
+RUN make STANDALONE=y | tee make0.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update && apt-get install -yq software-properties-common python-software-properties
-RUN add-apt-repository -y multiverse
+RUN . /etc/lsb-release; echo "deb http://archive.ubuntu.com/ubuntu/ $DISTRIB_CODENAME multiverse" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -yq \
     make \
     unrar \
@@ -27,6 +26,8 @@ RUN apt-get update && apt-get install -yq \
     bash \
     help2man \
     libtool-bin \
+    python \
+    python-dev \
     wget
 
 RUN useradd esp-open-sdk -m -G sudo


### PR DESCRIPTION
Use docker to build dedicated toolchain/dev-env container.
To use:-
- `docker build -t esp-open-sdk .` 
- wait [take a stroll even] and then 
- `docker run -it esp-open-sdk bash` 

and you're good to go ;)
