### PR TITLE
Add missing patch to be able to compile 1.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,8 +200,10 @@ sdk_patch: $(VENDOR_SDK_DIR)/.dir .sdk_patch_$(VENDOR_SDK)
 	$(PATCH) -d $(VENDOR_SDK_DIR) -p1 < dhcps_lease.patch
 	@touch $@
 
-.sdk_patch_1.3.0:
+.sdk_patch_1.3.0: user_interface.zip
 	echo -e "#undef ESP_SDK_VERSION\n#define ESP_SDK_VERSION 010300" >>$(VENDOR_SDK_DIR)/include/esp_sdk_ver.h
+	$(UNZIP) $<
+	mv user_interface.h $(VENDOR_SDK_DIR_1.3.0)/include/
 	$(PATCH) -d $(VENDOR_SDK_DIR) -p1 < c_types-c99.patch
 	@touch $@
 
@@ -370,6 +372,8 @@ lib_mem_optimize_150714.zip:
 	wget --content-disposition "http://bbs.espressif.com/download/file.php?id=594"
 Patch01_for_ESP8266_NONOS_SDK_V1.5.2.zip:
 	wget --content-disposition "http://bbs.espressif.com/download/file.php?id=1168"
+user_interface.zip:
+	wget --content-disposition "http://bbs.espressif.com/download/file.php?id=885"
 
 clean-sdk:
 	rm -rf $(VENDOR_SDK_DIR)


### PR DESCRIPTION
I needed 1.3.0, but it wouldn't compile, I got the same message as mentioned in:
http://bbs.espressif.com/viewtopic.php?t=1215
Using the supplied patch solved it:
http://bbs.espressif.com/viewtopic.php?f=46&t=1221.
It is for 1.4.0, but apparently also for 1.3.0.

Note: Is there a reason $(VENDOR_SDK_DIR_1.3.0)(etc.) and $(VENDOR_SDK_DIR) are used next to each other? I couldn't think of one, wasn't sure which would be the best to use :)

