### PR TITLE
Mention python-dev as development host dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Please make sure that the machine you use to build the toolchain has at least
 Ubuntu 14.04:
 ```
 $ sudo apt-get install make unrar autoconf automake libtool gcc g++ gperf \
-    flex bison texinfo gawk ncurses-dev libexpat-dev python python-serial sed \
-    git unzip bash help2man
+    flex bison texinfo gawk ncurses-dev libexpat-dev python-dev python python-serial \
+    sed git unzip bash help2man
 ```
 
 Later Debian/Ubuntu versions may require:


### PR DESCRIPTION
Fixes this toolchain build error:

[INFO ]  Installing cross-gdb
[ERROR]    configure: error: python is missing or unusable
[ERROR]    make[4]: *** [configure-gdb] Error 1
[ERROR]    make[3]: *** [all] Error 2
[ERROR]   
[ERROR]  >>
[ERROR]  >>  Build failed in step 'Installing cross-gdb'
[ERROR]  >>        called in step '(top-level)'
[ERROR]  >>
[ERROR]  >>  Error happened in: CT_DoExecLog[scripts/functions@257]
[ERROR]  >>        called from: do_debug_gdb_build[scripts/build/debug/300-gdb.sh@120]
[ERROR]  >>        called from: do_debug[scripts/build/debug.sh@35]
[ERROR]  >>        called from: main[scripts/crosstool-NG.sh@646]
[ERROR]  >>
[ERROR]  >>  For more info on this error, look at the file: 'build.log'
[ERROR]  >>  There is a list of known issues, some with workarounds, in:
[ERROR]  >>      'share/doc/crosstool-ng/crosstool-ng-1.22.0-55-gecfc19a/B - Known issues.txt'
[ERROR]   
[ERROR]  (elapsed: 26:36.59)
[26:37] / ct-ng:152: recipe for target 'build' failed
make[2]: *** [build] Error 2
make[2]: Leaving directory '/home/palha/esp8266/esp-open-sdk/crosstool-NG'
../Makefile:116: recipe for target '_toolchain' failed
make[1]: *** [_toolchain] Error 2
make[1]: Leaving directory '/home/palha/esp8266/esp-open-sdk/crosstool-NG'
Makefile:112: recipe for target '/home/palha/esp8266/esp-open-sdk/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc' failed
make: *** [/home/palha/esp8266/esp-open-sdk/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc] Error 2