### PR TITLE
Add support for Espressif SDK 1.5.4 and switch the default to it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.sdk_patch_*
 /esp_iot_sdk_v*/
 /esp_iot_sdk_v*.zip
-/ESP8266_NONOS_SDK_V1.5.1_16_01_08.zip
+/ESP8266_NONOS_SDK*
+/release_note.txt
 /sdk
 /xtensa-lx106-elf/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TOOLCHAIN = $(TOP)/xtensa-lx106-elf
 
 # Vendor SDK version to install, see VENDOR_SDK_ZIP_* vars below
 # for supported versions.
-VENDOR_SDK = 1.5.2
+VENDOR_SDK = 1.5.4
 
 .PHONY: crosstool-NG toolchain libhal libcirom sdk
 
@@ -23,6 +23,8 @@ UNZIP = unzip -q -o
 VENDOR_SDK_ZIP = $(VENDOR_SDK_ZIP_$(VENDOR_SDK))
 VENDOR_SDK_DIR = $(VENDOR_SDK_DIR_$(VENDOR_SDK))
 
+VENDOR_SDK_ZIP_1.5.4 = ESP8266_NONOS_SDK_V1.5.4_16_05_20.zip
+VENDOR_SDK_DIR_1.5.4 = ESP8266_NONOS_SDK
 VENDOR_SDK_ZIP_1.5.3 = ESP8266_NONOS_SDK_V1.5.3_16_04_18.zip
 VENDOR_SDK_DIR_1.5.3 = ESP8266_NONOS_SDK_V1.5.3_16_04_18/ESP8266_NONOS_SDK
 VENDOR_SDK_ZIP_1.5.2 = ESP8266_NONOS_SDK_V1.5.2_16_01_29.zip
@@ -163,10 +165,16 @@ sdk: $(VENDOR_SDK_DIR)/.dir
 
 $(VENDOR_SDK_DIR)/.dir: $(VENDOR_SDK_ZIP)
 	$(UNZIP) $^
-	-mv License $(VENDOR_SDK_DIR)
+	#-mv License $(VENDOR_SDK_DIR)
 	touch $@
 
 sdk_patch: $(VENDOR_SDK_DIR)/.dir .sdk_patch_$(VENDOR_SDK)
+
+.sdk_patch_1.5.4:
+	echo -e "#undef ESP_SDK_VERSION\n#define ESP_SDK_VERSION 010504" >>$(VENDOR_SDK_DIR)/include/esp_sdk_ver.h
+	$(PATCH) -d $(VENDOR_SDK_DIR) -p1 < c_types-c99.patch
+	cd $(VENDOR_SDK_DIR)/lib; mkdir -p tmp; cd tmp; $(TOOLCHAIN)/bin/xtensa-lx106-elf-ar x ../libcrypto.a; cd ..; $(TOOLCHAIN)/bin/xtensa-lx106-elf-ar rs libwpa.a tmp/*.o
+	@touch $@
 
 .sdk_patch_1.5.3:
 	echo -e "#undef ESP_SDK_VERSION\n#define ESP_SDK_VERSION 010503" >>$(VENDOR_SDK_DIR)/include/esp_sdk_ver.h
@@ -303,6 +311,8 @@ ifeq ($(STANDALONE),y)
 	    $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/include/
 endif
 
+ESP8266_NONOS_SDK_V1.5.4_16_05_20.zip:
+	wget --content-disposition "http://bbs.espressif.com/download/file.php?id=1469"
 ESP8266_NONOS_SDK_V1.5.3_16_04_18.zip:
 	wget --content-disposition "http://bbs.espressif.com/download/file.php?id=1361"
 ESP8266_NONOS_SDK_V1.5.2_16_01_29.zip:


### PR DESCRIPTION
I'm not sure I made it correctly but it works for me. I'm wondering about the mv License I commented out, since the zip now extracts in a subdirectory.