### PR TITLE
MacOS build needs help2man

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ sudo apt-get install libtool-bin
 ## MacOS:
 ```bash
 $ brew tap homebrew/dupes
-$ brew install binutils coreutils automake wget gawk libtool gperf gnu-sed --with-default-names grep
+$ brew install binutils coreutils automake wget gawk libtool help2man gperf gnu-sed --with-default-names grep
 $ export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 


### PR DESCRIPTION
configure fails with the following

    checking for gzip... gzip
    checking for bzip2... bzip2
    checking for help2man... no
    configure: error: missing required tool: help2man
    make[1]: *** [_ct-ng] Error 1
    make: *** [crosstool-NG/ct-ng] Error 2