### PR TITLE
Added help2man to the brew install dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ sudo apt-get install libtool-bin
 ## MacOS:
 ```bash
 $ brew tap homebrew/dupes
-$ brew install binutils coreutils automake wget gawk libtool gperf gnu-sed --with-default-names grep
+$ brew install binutils coreutils automake wget gawk help2man libtool gperf gnu-sed --with-default-names grep
 $ export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 


### PR DESCRIPTION
help2man seems to be required to build this, this adds it to the `brew install` instructions for MacOS users.