### PR TITLE
Changed dependency unrar to unrar-free.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please make sure that the machine you use to build the toolchain has at least
 
 Ubuntu 14.04:
 ```
-$ sudo apt-get install make unrar autoconf automake libtool gcc g++ gperf \
+$ sudo apt-get install make unrar-free autoconf automake libtool gcc g++ gperf \
     flex bison texinfo gawk ncurses-dev libexpat-dev python-dev python python-serial \
     sed git unzip bash help2man wget bzip2
 ```


### PR DESCRIPTION
Debian does not include unrar in default repositories, because it is not free. But does include unrar-free and also Ubuntu has it.