### PR TITLE
Provide compiler specs with default esp8266-specific libraries/map file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ toolchain: $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
 $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc: crosstool-NG/ct-ng
 	cp -f 1000-mforce-l32.patch crosstool-NG/local-patches/gcc/4.8.5/
 	make -C crosstool-NG -f ../Makefile _toolchain
+	cp -f specs $(TOOLCHAIN)/lib/gcc/xtensa-lx106-elf/4.8.5
 
 _toolchain:
 	./ct-ng xtensa-lx106-elf

--- a/examples/blinky/Makefile
+++ b/examples/blinky/Makefile
@@ -1,7 +1,5 @@
 CC = xtensa-lx106-elf-gcc
 CFLAGS = -I. -mlongcalls
-LDLIBS = -nostdlib -Wl,--start-group -lmain -lnet80211 -lwpa -llwip -lpp -lphy -Wl,--end-group -lgcc
-LDFLAGS = -Teagle.app.v6.ld
 
 blinky-0x00000.bin: blinky
 	esptool.py elf2image $^

--- a/specs
+++ b/specs
@@ -1,0 +1,9 @@
+*lib:
+--start-group -lmain -lnet80211 -lwpa -llwip -lpp -lphy -lc --end-group %{!T:-Teagle.app.v6.ld}
+
+*startfile:
+
+
+*endfile:
+
+


### PR DESCRIPTION
This series fixes issue #199 and also fixes examples/blinky build (which now requires linking with libc b/o liblwip.a(espconn_buf.o)).