### PR TITLE
Makefile: changes in PATH for Cygwin 64 bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,9 +163,9 @@ $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/libhal.a: $(TOOLCHAIN)/bin/xtensa-
 
 _libhal:
 	autoreconf -i
-	PATH=$(TOOLCHAIN)/bin:$(PATH) ./configure --host=xtensa-lx106-elf --prefix=$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr
-	PATH=$(TOOLCHAIN)/bin:$(PATH) make
-	PATH=$(TOOLCHAIN)/bin:$(PATH) make install
+	PATH="$(TOOLCHAIN)/bin:$(PATH)" ./configure --host=xtensa-lx106-elf --prefix=$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr
+	PATH="$(TOOLCHAIN)/bin:$(PATH)" make
+	PATH="$(TOOLCHAIN)/bin:$(PATH)" make install
 
 
 


### PR DESCRIPTION
Added quotation marks at 166, 167 and 168 line - without it compilation on Cygwin 64b isn't possible. PATH on Windows 64b can contain spaces i.e. `C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common` which causing problem. Shoudn't affect Linux.
