### PR TITLE
make user_rf_cal_sector_set a weak symbol so it can be overridden

### DIFF
--- a/user_rf_cal_sector_set.c
+++ b/user_rf_cal_sector_set.c
@@ -1,6 +1,11 @@
 #include <c_types.h>
 #include <spi_flash.h>
 
+/* Set the target flash sector to store RF_CAL parameters from user controlled
+ * flash storage space..
+ * Make this a weak symbol so a program can easily supply their own version.
+ */
+__attribute__ ((weak))
 uint32 user_rf_cal_sector_set(void) {
     extern char flashchip;
     SpiFlashChip *flash = (SpiFlashChip*)(&flashchip + 4);


### PR DESCRIPTION
This gives the user control of where the sector is allocated if they so choose or they get the default and don't have to think about it.  I ran into a problem of not being able to compile esp-link because of the duplicate symbol (they defined it as well).