### PR TITLE
examples/blinky: add -lc to LDLIBS for memchr

### DIFF
--- a/examples/blinky/Makefile
+++ b/examples/blinky/Makefile
@@ -1,6 +1,6 @@
 CC = xtensa-lx106-elf-gcc
 CFLAGS = -I. -mlongcalls
-LDLIBS = -nostdlib -Wl,--start-group -lmain -lnet80211 -lwpa -llwip -lpp -lphy -Wl,--end-group -lgcc
+LDLIBS = -nostdlib -Wl,--start-group -lmain -lnet80211 -lwpa -llwip -lpp -lphy -lc -Wl,--end-group -lgcc
 LDFLAGS = -Teagle.app.v6.ld
 
 blinky-0x00000.bin: blinky


### PR DESCRIPTION
Hi Paul,
please pull this fix for the issue #213.
Thanks.
-- Max