### PR TITLE
Corrected 'sussystem' to 'subsystem'

### DIFF
--- a/examples/blinky/blinky.c
+++ b/examples/blinky/blinky.c
@@ -23,7 +23,7 @@ void some_timerfunc(void *arg)
 
 void ICACHE_FLASH_ATTR user_init()
 {
-  // init gpio sussytem
+  // init gpio subsytem
   gpio_init();
 
   // configure UART TXD to be GPIO1, set as output


### PR DESCRIPTION
a simple spelling fix