### PR TITLE
examples/blinky/Makefile: fixed flash offsets / filenames

### DIFF
--- a/examples/blinky/Makefile
+++ b/examples/blinky/Makefile
@@ -11,7 +11,7 @@ blinky: blinky.o
 blinky.o: blinky.c
 
 flash: blinky-0x00000.bin
-	esptool.py write_flash 0 blinky-0x00000.bin 0x40000 blinky-0x40000.bin
+	esptool.py write_flash 0 blinky-0x00000.bin 0x10000 blinky-0x10000.bin
 
 clean:
-	rm -f blinky blinky.o blinky-0x00000.bin blinky-0x40000.bin
+	rm -f blinky blinky.o blinky-0x00000.bin blinky-0x10000.bin


### PR DESCRIPTION
Fix so that `make flash` works for the blinky example.