### PR TITLE
Add cross-gdb configure flags to work around upstream bugs

### DIFF
--- a/crosstool-config-overrides
+++ b/crosstool-config-overrides
@@ -2,4 +2,5 @@
 # by default don't install static libs for all required dependencies
 #CT_STATIC_TOOLCHAIN=y
 CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
+CT_GDB_CROSS_EXTRA_CONFIG_ARRAY="--with-guile=guile-2.0 --disable-tui"
 


### PR DESCRIPTION
Here's a one-liner patch to `crosstool-config-overrides` to mitigate problems with building `cross-gdb` on certain platforms.

`--with-guile=guile-2.0`: some distros (like Arch) have guile 2.2 as the default version, but `gdb` can't be built against that ([upstream bug report](https://sourceware.org/bugzilla/show_bug.cgi?id=21104)). This flag tells `gdb` to build against `guile-2.0`.

`--disable-tui`: some distros provide `ncurses` and `tinfo` as separate packages. Apparently `gdb` doesn't detect this properly and fails to link against `tinfo`. These libraries are only required for the TUI, so disable it until this is fixed. [crosstool-NG bug report](https://github.com/crosstool-ng/crosstool-ng/issues/321)