### PR TITLE
Strip ROM symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ esptool: toolchain
 	cp esptool/esptool.py $(TOOLCHAIN)/bin/
 
 toolchain: $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
+	cp strip_libgcc_funcs.txt $(TOOLCHAIN)/lib/gcc/xtensa-lx106-elf/$(shell $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc -dumpversion)/
+	cd $(TOOLCHAIN)/lib/gcc/xtensa-lx106-elf/$(shell $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc -dumpversion)/; $(TOOLCHAIN)/bin/xtensa-lx106-elf-ar -M < strip_libgcc_funcs.txt; rm strip_libgcc_funcs.txt
+	cp strip_libc_funcs.txt $(TOOLCHAIN)/xtensa-lx106-elf/lib
+	cd $(TOOLCHAIN)/xtensa-lx106-elf/lib; $(TOOLCHAIN)/bin/xtensa-lx106-elf-ar -M < strip_libc_funcs.txt; rm strip_libc_funcs.txt
 
 $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc: crosstool-NG/ct-ng
 	cp -f 1000-mforce-l32.patch crosstool-NG/local-patches/gcc/4.8.5/

--- a/strip_libc_funcs.txt
+++ b/strip_libc_funcs.txt
@@ -1,0 +1,15 @@
+OPEN libc.a
+DELETE lib_a-bzero.o
+DELETE lib_a-memcmp.o
+DELETE lib_a-memcpy.o
+DELETE lib_a-memmove.o
+DELETE lib_a-memset.o
+DELETE lib_a-rand.o
+DELETE lib_a-strcmp.o
+DELETE lib_a-strcpy.o
+DELETE lib_a-strlen.o
+DELETE lib_a-strncmp.o
+DELETE lib_a-strncpy.o
+DELETE lib_a-strstr.o
+SAVE
+END

--- a/strip_libgcc_funcs.txt
+++ b/strip_libgcc_funcs.txt
@@ -1,0 +1,25 @@
+OPEN libgcc.a
+DELETE _addsubdf3.o
+DELETE _addsubsf3.o
+DELETE _divdf3.o
+DELETE _divdi3.o
+DELETE _divsi3.o
+DELETE _extendsfdf2.o
+DELETE _fixdfsi.o
+DELETE _fixunsdfsi.o
+DELETE _fixunssfsi.o
+DELETE _floatsidf.o
+DELETE _floatsisf.o
+DELETE _floatunsidf.o
+DELETE _floatunsisf.o
+DELETE _muldf3.o
+DELETE _muldi3.o
+DELETE _mulsf3.o
+DELETE _truncdfsf2.o
+DELETE _udivdi3.o
+DELETE _udivsi3.o
+DELETE _umoddi3.o
+DELETE _umodsi3.o
+DELETE _umulsidi3.o
+SAVE
+END


### PR DESCRIPTION
Quite a few library functions in libgcc.a and libc.a exist in the chip ROM. Previously the duplicate functions in the esp-open-sdk built libgcc were masked by Espressif supplying their own stripped libgcc.a in the SDK, however the functions in the built libc would always have ended up being used over the ROM versions. This would lead to larger and potentially slower code and possibly even memory allocation differences. Since quite a few core string manipulation functions are some of the ones in ROM, this could be significant.

Espressif has recently added an ar script (based on my libgcc script, but with corrected set of object files) into the SDK. This change adds them to the Makefile

