### PR TITLE
Improve rules and instructions for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ ifeq ($(STANDALONE),y)
 	@echo "Installing vendor SDK libs into toolchain sysroot"
 	@cp -Rf sdk/lib/* $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/
 	@echo "Installing vendor SDK linker scripts into toolchain sysroot"
-	@sed -e 's/\r//' sdk/ld/eagle.app.v6.ld | sed -e s@../ld/@@ >$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/eagle.app.v6.ld
-	@sed -e 's/\r//' sdk/ld/eagle.rom.addr.v6.ld >$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/eagle.rom.addr.v6.ld
+	@tr -d '\r' <sdk/ld/eagle.app.v6.ld | sed -e s@../ld/@@ >$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/eagle.app.v6.ld
+	@tr -d '\r' <sdk/ld/eagle.rom.addr.v6.ld >$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/eagle.rom.addr.v6.ld
 endif
 
 clean: clean-sdk
@@ -130,8 +130,8 @@ $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc: crosstool-NG/ct-ng
 
 _toolchain:
 	./ct-ng xtensa-lx106-elf
-	sed -r -i.org s%CT_PREFIX_DIR=.*%CT_PREFIX_DIR="$(TOOLCHAIN)"% .config
-	sed -r -i s%CT_INSTALL_DIR_RO=y%"#"CT_INSTALL_DIR_RO=y% .config
+	sed -i.orig s%^CT_PREFIX_DIR=.*%CT_PREFIX_DIR="$(TOOLCHAIN)"% .config
+	sed -i.orig s%^CT_INSTALL_DIR_RO=y%"#"CT_INSTALL_DIR_RO=y% .config
 	cat ../crosstool-config-overrides >> .config
 	./ct-ng build
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,16 @@ $ sudo apt-get install libtool-bin
 ```
 
 ## MacOS:
+
+Using Homebrew:
 ```bash
 $ brew tap homebrew/dupes
 $ brew install binutils coreutils automake wget gawk libtool help2man gperf gnu-sed --with-default-names grep
+```
+
+Using MacPorts:
+```bash
+$ sudo port -N install binutils autoconf automake libtool wget gperf gsed gawk help2man
 ```
 
 In addition to the development tools MacOS needs a case-sensitive filesystem.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ $ sudo apt-get install libtool-bin
 ```bash
 $ brew tap homebrew/dupes
 $ brew install binutils coreutils automake wget gawk libtool help2man gperf gnu-sed --with-default-names grep
-$ export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 
 In addition to the development tools MacOS needs a case-sensitive filesystem.


### PR DESCRIPTION
These commits convert and replace the GNU sed commands in Makefile to a portable syntax, which will remove the requirement to modify PATH on macOS. Add instructions which ports need to be installed when using MacPorts instead of Homebrew.