### PR TITLE
Fix #347 by adding rule for building libc.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ endif
 
 clean: clean-sdk
 	$(MAKE) -C crosstool-NG clean MAKELEVEL=0
+	-rm -f crosstool-NG/.built
 	-rm -rf crosstool-NG/.build/src
 	-rm -f crosstool-NG/local-patches/gcc/4.8.5/1000-*
 	-rm -rf $(TOOLCHAIN)
@@ -123,11 +124,12 @@ clean-sysroot:
 esptool: toolchain
 	cp esptool/esptool.py $(TOOLCHAIN)/bin/
 
-toolchain: $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
+toolchain $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/lib/libc.a: crosstool-NG/.built
 
-$(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc: crosstool-NG/ct-ng
+crosstool-NG/.built: crosstool-NG/ct-ng
 	cp -f 1000-mforce-l32.patch crosstool-NG/local-patches/gcc/4.8.5/
 	$(MAKE) -C crosstool-NG -f ../Makefile _toolchain
+	touch $@
 
 _toolchain:
 	./ct-ng xtensa-lx106-elf


### PR DESCRIPTION
Hi Paul,

please merge the fix for issue #347. With that change it is possible to run make -j successfully.

Thanks.
-- Max
