### PR TITLE
Use env shell cmd in Makefile for portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ VENDOR_SDK = 2.1.0-18-g61248df
 
 
 TOP = $(PWD)
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 PATCH = patch -b -N
 UNZIP = unzip -q -o
 VENDOR_SDK_ZIP = $(VENDOR_SDK_ZIP_$(VENDOR_SDK))


### PR DESCRIPTION
I suggest using the
```
/usr/bin/env bash
```
instead of just
```
/bin/bash
```
in shell scripts, for [portability](https://en.wikipedia.org/wiki/Env).

For example, this fixes the build for NixOS users (like me).