### PR TITLE
Fix ubuntu 21.10 build

### DIFF
--- a/1000-fix-build-python3.9.patch
+++ b/1000-fix-build-python3.9.patch
@@ -1,0 +1,44 @@
+Fix error building gdb-7.10 with python 3.9 (e.g. on Ubuntu 21.10), by fixing gdb to not use an internal-only API.
+
+As suggested by canardos in their 2018-08-28 comment on https://github.com/pfalcon/esp-open-sdk/issues/339
+applying (by hand) this patch: https://sourceware.org/legacy-ml/gdb-patches/2018-05/msg00863.html
+to gdb/python.c fixed the issue.  This patch is the diff that resulted.
+
+--- gdb-7.10/gdb/python/python.c~	2015-08-28 14:22:07.000000000 -0700
++++ gdb-7.10/gdb/python/python.c	2022-01-06 12:44:24.136568791 -0800
+@@ -1622,6 +1622,14 @@
+ }
+ #endif
+ 
++#ifdef IS_PY3K
++PyMODINIT_FUNC
++PyInit__gdb (void)
++{
++  return PyModule_Create (&python_GdbModuleDef);
++}
++#endif
++
+ /* Provide a prototype to silence -Wmissing-prototypes.  */
+ extern initialize_file_ftype _initialize_python;
+ 
+@@ -1743,6 +1751,9 @@
+      remain alive for the duration of the program's execution, so
+      it is not freed after this call.  */
+   Py_SetProgramName (progname_copy);
++
++  /* Define _gdb as a built-in module.  */
++  PyImport_AppendInittab ("_gdb", PyInit__gdb);
+ #else
+   Py_SetProgramName (progname);
+ #endif
+@@ -1752,9 +1763,7 @@
+   PyEval_InitThreads ();
+ 
+ #ifdef IS_PY3K
+-  gdb_module = PyModule_Create (&python_GdbModuleDef);
+-  /* Add _gdb module to the list of known built-in modules.  */
+-  _PyImport_FixupBuiltin (gdb_module, "_gdb");
++  gdb_module = PyImport_ImportModule ("_gdb");
+ #else
+   gdb_module = Py_InitModule ("_gdb", python_GdbMethods);
+ #endif

--- a/1001-fix-reload1-compile-error.patch
+++ b/1001-fix-reload1-compile-error.patch
@@ -1,0 +1,17 @@
+Avoid gcc/reload1.c compile error when building with newer gcc (e.g. gcc 11.2 on Ubuntu 21.10).
+
+The error was:
+
+.../esp-open-sdk/crosstool-NG/.build/src/gcc-4.8.5/gcc/reload1.c:89:24: error: use of an operand of type 'bool' in 'operator++' is forbidden in C++17
+
+--- gcc-4.8.5/gcc/reload1.c~	2013-01-21 06:55:05.000000000 -0800
++++ gcc-4.8.5/gcc/reload1.c	2022-01-05 17:18:10.148547719 -0800
+@@ -440,7 +440,7 @@
+ 
+   while (memory_address_p (QImode, tem))
+     {
+-      spill_indirect_levels++;
++      spill_indirect_levels = 1;
+       tem = gen_rtx_MEM (Pmode, tem);
+     }
+ 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ crosstool-NG/ct-ng: crosstool-NG/bootstrap
 
 _ct-ng:
 	./bootstrap
-	./configure --prefix=`pwd`
+	./configure --prefix=`pwd` --with-bash=/bin/bash
 	$(MAKE) MAKELEVEL=0
 	$(MAKE) install MAKELEVEL=0
 

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ toolchain $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc $(TOOLCHAIN)/xtensa-lx106-elf/sy
 
 crosstool-NG/.built: crosstool-NG/ct-ng
 	cp -f 1000-mforce-l32.patch crosstool-NG/local-patches/gcc/4.8.5/
+	cp -f 1001-fix-reload1-compile-error.patch crosstool-NG/local-patches/gcc/4.8.5/
 	$(MAKE) -C crosstool-NG -f ../Makefile _toolchain
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,8 @@ toolchain $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc $(TOOLCHAIN)/xtensa-lx106-elf/sy
 crosstool-NG/.built: crosstool-NG/ct-ng
 	cp -f 1000-mforce-l32.patch crosstool-NG/local-patches/gcc/4.8.5/
 	cp -f 1001-fix-reload1-compile-error.patch crosstool-NG/local-patches/gcc/4.8.5/
+	mkdir -p crosstool-NG/local-patches/gdb/7.10/
+	cp -f 1000-fix-build-python3.9.patch crosstool-NG/local-patches/gdb/7.10/
 	$(MAKE) -C crosstool-NG -f ../Makefile _toolchain
 	touch $@
 
@@ -144,7 +146,7 @@ crosstool-NG: crosstool-NG/ct-ng
 
 crosstool-NG/ct-ng: crosstool-NG/bootstrap
 	test -s crosstool-NG/scripts/build/companion_libs/121-isl.sh.orig || $(PATCH) -p1 -i ctng-fix-isl-url.patch
-	test -s crosstool-NG/scripts/build/companion_libs/210-expat.sh.orig || $(PATCH) -p1 -i ctng-fix-expat-url.patch	
+	test -s crosstool-NG/scripts/build/companion_libs/210-expat.sh.orig || $(PATCH) -p1 -i ctng-fix-expat-url.patch
 	$(MAKE) -C crosstool-NG -f ../Makefile _ct-ng
 
 _ct-ng:

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ crosstool-NG: crosstool-NG/ct-ng
 
 crosstool-NG/ct-ng: crosstool-NG/bootstrap
 	test -s crosstool-NG/scripts/build/companion_libs/121-isl.sh.orig || $(PATCH) -p1 -i ctng-fix-isl-url.patch
+	test -s crosstool-NG/scripts/build/companion_libs/210-expat.sh.orig || $(PATCH) -p1 -i ctng-fix-expat-url.patch	
 	$(MAKE) -C crosstool-NG -f ../Makefile _ct-ng
 
 _ct-ng:

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ _toolchain:
 crosstool-NG: crosstool-NG/ct-ng
 
 crosstool-NG/ct-ng: crosstool-NG/bootstrap
+	test -s crosstool-NG/scripts/build/companion_libs/121-isl.sh.orig || $(PATCH) -p1 -i ctng-fix-isl-url.patch
 	$(MAKE) -C crosstool-NG -f ../Makefile _ct-ng
 
 _ct-ng:

--- a/ctng-fix-expat-url.patch
+++ b/ctng-fix-expat-url.patch
@@ -1,0 +1,14 @@
+diff --git a/scripts/build/companion_libs/210-expat.sh b/scripts/build/companion_libs/210-expat.sh
+index 304482cd..dc1085d2 100644
+--- a/crosstool-NG/scripts/build/companion_libs/210-expat.sh
++++ b/crosstool-NG/scripts/build/companion_libs/210-expat.sh
+@@ -10,7 +10,8 @@ if [ "${CT_EXPAT_TARGET}" = "y" -o "${CT_EXPAT}" = "y" ]; then
+ 
+ do_expat_get() {
+     CT_GetFile "expat-${CT_EXPAT_VERSION}" .tar.gz    \
+-               http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}
++	       https://src.fedoraproject.org/repo/pkgs/expat/expat-${CT_EXPAT_VERSION}.tar.gz/dd7dab7a5fea97d2a6a43f511449b7cd
++               # http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}
+ }
+ 
+ do_expat_extract() {

--- a/ctng-fix-expat-url.patch
+++ b/ctng-fix-expat-url.patch
@@ -1,3 +1,15 @@
+Fix to get expat-2.1.0.tar.gz from a different location, since it is no longer
+available from the one that had been used.
+
+NOTE: The reason the old location didn't work is that expat-2.1.0.tar.gz on
+sourceforge had been renamed to
+"expat-2.1.0-RENAMED-VULNERABLE-PLEASE-USE-2.3.0-INSTEAD.tar.gz"... I
+considered seeing if it would work using 2.3.0 as suggested, but 2.3.0
+similarly redirects to 2.4.1, and the immediate goal is to get this stuff to
+build with minimally intrusive changes.
+
+However, it would probably be wise to switch to a newer expat!
+
 diff --git a/scripts/build/companion_libs/210-expat.sh b/scripts/build/companion_libs/210-expat.sh
 index 304482cd..dc1085d2 100644
 --- a/crosstool-NG/scripts/build/companion_libs/210-expat.sh

--- a/ctng-fix-isl-url.patch
+++ b/ctng-fix-isl-url.patch
@@ -1,3 +1,7 @@
+Fix to get isl-0.14.tar.bz2 from a different location, since isl.gforge.inria.fr seems to no longer work.
+
+This is from: https://github.com/pfalcon/esp-open-sdk/issues/386
+
 diff --git a/scripts/build/companion_libs/121-isl.sh b/scripts/build/companion_libs/121-isl.sh
 index a93d1aad..ca0a7f16 100644
 --- a/crosstool-NG/scripts/build/companion_libs/121-isl.sh

--- a/ctng-fix-isl-url.patch
+++ b/ctng-fix-isl-url.patch
@@ -1,0 +1,14 @@
+diff --git a/scripts/build/companion_libs/121-isl.sh b/scripts/build/companion_libs/121-isl.sh
+index a93d1aad..ca0a7f16 100644
+--- a/crosstool-NG/scripts/build/companion_libs/121-isl.sh
++++ b/crosstool-NG/scripts/build/companion_libs/121-isl.sh
+@@ -14,7 +14,8 @@ if [ "${CT_ISL}" = "y" ]; then
+ # Download ISL
+ do_isl_get() {
+     CT_GetFile "isl-${CT_ISL_VERSION}" \
+-        http://isl.gforge.inria.fr
++	http://gcc.gnu.org/pub/gcc/infrastructure
++        # http://isl.gforge.inria.fr
+ }
+ 
+ # Extract ISL


### PR DESCRIPTION
This is a minimal set of changes to get the build to work on Ubuntu 21.10, which (based on the numerous posts, issues, questions, etc. that I found in the course of figuring out how to get this to build) would apparently save a lot of people a lot of trouble.  The MicroPython ESP8266 port points to your repo, so anyone trying to follow those instructions is going to run into these same problems.